### PR TITLE
feat: création d'une database pour faire les tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,17 @@
+TZ=UTC
+PORT=3333
+HOST=localhost
+LOG_LEVEL=info
+APP_KEY=srlgqhukerqghrjoqghzuietghith
+NODE_ENV=testing
+SESSION_DRIVER=cookie
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_USER=user_ogmaker_test
+DB_PASSWORD=test_password
+DB_DATABASE=db_ogmaker_test
+SMTP_HOST=sandbox.smtp.mailtrap.io
+SMTP_PORT=2525
+SMTP_USERNAME=1f61b3f8b27b82
+SMTP_PASSWORD=a5249f7f4d68c7
+APP_URL=http://$HOST:$PORT

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,0 +1,18 @@
+aTZ=UTC
+PORT=3333
+HOST=localhost
+LOG_LEVEL=info
+APP_KEY=srlgqhukerqghrjoqghzuietghith
+NODE_ENV=testing
+SESSION_DRIVER=cookie
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_USER=user_ogmaker_test
+DB_PASSWORD=test_password
+DB_DATABASE=db_ogmaker_test
+SMTP_HOST=sandbox.smtp.mailtrap.io
+SMTP_PORT=2525
+# Go to your mailtrap.io account and find the sandbox credentials in your inbox integration
+SMTP_USERNAME=
+SMTP_PASSWORD=
+APP_URL=http:$HOST:$PORT

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp
 
 # Secrets
 .env
+.env.testing
 .env.local
 .env.production.local
 .env.development.local

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ Password : 12345678
 ## Type of URL needed for the OpenGraph's images
 
 Not all URLs works for uploading a new graph with an image. To ensure it works, you have to use an URL from [Cloudinary](https://cloudinary.com)
+
+## Testing
+
+If you want to try and do the tests, [everything you need to know is here](TESTING.md)

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,5 +1,26 @@
 # COMMENT TESTER 
 
+## CREER UNE NOUVELLE BDD POUR LES TESTS
+
+Open SQL CLI
+
+- Linux or mac: `sudo -u postgres psql`
+- Windows: `psql -U postgres`
+
+```bash
+CREATE DATABASE db_ogmaker_test;
+CREATE USER user_ogmaker_test WITH SUPERUSER PASSWORD 'test_password';
+GRANT ALL PRIVILEGES ON DATABASE db_ogmaker_test TO user_ogmaker_test;
+ALTER DATABASE db_ogmaker_test OWNER TO user_ogmaker_test;
+
+```
+
+## ENV VAR DE TESTING
+
+Copier .env.testing.example dans .env.testing
+
+## REGISTER
+
 - Quand je vais sur /register j'ai le formulaire de création de compte qui s'affiche
 - Quand je vais sur /register, et que je remplie tous les champs de manière correcte, un nouveau compte est créé
 - Quand je vais sur /register, et que je remplie tous les champs de manière correcte sauf le mot de passe qui est trop court, on reste sur la même page et une erreur s'affiche

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,9 @@
         "ts-node-maintained": "^10.9.4",
         "typescript": "~5.7",
         "vite": "^6.0.3"
+      },
+      "devDependencies": {
+        "cross-env": "^7.0.3"
       }
     },
     "node_modules/@adonisjs/ace": {
@@ -3799,6 +3802,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node bin/server.js",
     "build": "node ace build",
     "dev": "node ace serve --hmr",
-    "test": "node ace test",
+    "test": "cross-env NODE_ENV=testing node ace test",
     "lint": "eslint .",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit"
@@ -86,5 +86,8 @@
       "strtok3": "8.0.1"
     }
   },
-  "prettier": "@adonisjs/prettier-config"
+  "prettier": "@adonisjs/prettier-config",
+  "devDependencies": {
+    "cross-env": "^7.0.3"
+  }
 }

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -3,6 +3,14 @@ import app from '@adonisjs/core/services/app'
 import type { Config } from '@japa/runner/types'
 import { pluginAdonisJS } from '@japa/plugin-adonisjs'
 import testUtils from '@adonisjs/core/services/test_utils'
+import { config } from 'dotenv'
+
+// Charger les variables d'environnement en fonction de l'environnement
+if (process.env.NODE_ENV === 'testing') {
+  config({ path: '.env.test' })
+} else {
+  config()
+}
 
 /**
  * This file is imported by the "bin/test.ts" entrypoint file
@@ -15,7 +23,7 @@ import testUtils from '@adonisjs/core/services/test_utils'
 export const plugins: Config['plugins'] = [assert(), pluginAdonisJS(app)]
 
 /**
- * Configure lifecycle function to run before and after all the
+ * Configure lifecycle functions to run before and after all the
  * tests.
  *
  * The setup functions are executed before all the tests

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import adonisjs from '@adonisjs/vite/client'
-import tailwind from 'tailwindcss';
-import autoprefixer from 'autoprefixer';
+import tailwind from 'tailwindcss'
+import autoprefixer from 'autoprefixer'
 
 export default defineConfig({
   plugins: [
@@ -18,5 +18,5 @@ export default defineConfig({
       reload: ['resources/views/**/*.edge'],
     }),
   ],
-  css: { postcss: { plugins: [tailwind(), autoprefixer()] } }
+  css: { postcss: { plugins: [tailwind(), autoprefixer()] } },
 })


### PR DESCRIPTION
Le README.md a été modifié pour la création de la nouvelle BDD. Les infos sont dans 'TESTING.md'

Dupliquer .env.testing.example, remplir la partie mailtrap avec ces propres infos

Créer la nouvelle BDD qui sont marqué dans le TESTING.md

Faire une npm install pour installer 'cross-env'

Et voilà on peut faire les tests sans drop notre BDD !